### PR TITLE
remove ENV from validator.env file

### DIFF
--- a/validator.env
+++ b/validator.env
@@ -1,6 +1,3 @@
-# Valid environments are "prod" and "testnet"
-ENV=prod
-
 # Allowed characters A-Z, a-z, 0-9, _, -, and space
 STRATEGY_EXECUTOR_DISPLAY_NAME=
 


### PR DESCRIPTION
Some users is confused about ENV

removed it because it is no longer in use

<img width="621" alt="スクリーンショット 2025-02-23 1 17 00" src="https://github.com/user-attachments/assets/2696b092-2ac1-4340-894e-e1bcbb6b622f" />
